### PR TITLE
Single quote replacement

### DIFF
--- a/src/postgres.coffee
+++ b/src/postgres.coffee
@@ -28,6 +28,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 squel.flavours['postgres'] = ->
   cls = squel.cls
 
+  # If true then replaces all single quotes. The replacement string used is configurable via the singleQuoteReplacement option
+  cls.DefaultQueryBuilderOptions.replaceSingleQuotes = false
+  # The single quote string to replace single quotes in queries
+  cls.DefaultQueryBuilderOptions.singleQuoteReplacement = '\'\''
+
   # RETURNING
   class cls.ReturningBlock extends cls.Block
     constructor: (options) ->
@@ -51,4 +56,9 @@ squel.flavours['postgres'] = ->
         new cls.ReturningBlock(options)
       ]
       super options, blocks
+
+  # Escape strings using the options
+  cls.BaseBuilder.prototype._escapeValue = (value) ->
+    return value unless true is @options.replaceSingleQuotes
+    value.replace /\'/g, @options.singleQuoteReplacement
 

--- a/src/squel.coffee
+++ b/src/squel.coffee
@@ -217,6 +217,9 @@ class cls.BaseBuilder extends cls.Cloneable
         throw new Error "field value must be a string, number, boolean, null or one of the registered custom value types"
     item
 
+  # Escapes the string value. This is a placeholder for the flavours to implement it.
+  _escapeValue: (value) -> value
+
   # Format the given field value for inclusion into the query string
   _formatValue: (value) ->
     # user defined custom handlers takes precedence
@@ -231,6 +234,7 @@ class cls.BaseBuilder extends cls.Cloneable
       value = if value then "TRUE" else "FALSE"
     else if "number" isnt typeof value
       if false is @options.usingValuePlaceholders
+        value = @_escapeValue(value)
         value = "'#{value}'"
     value
 

--- a/test/postgres.test.coffee
+++ b/test/postgres.test.coffee
@@ -46,6 +46,42 @@ test['Postgres flavour'] =
       toString: ->
         assert.same @inst.toString(), 'INSERT INTO table (field) VALUES (1) RETURNING id'
 
+  'Default query builder options': ->
+    assert.same {
+      replaceSingleQuotes: false,
+      singleQuoteReplacement: "''",
+      autoQuoteTableNames: false
+      autoQuoteFieldNames: false
+      autoQuoteAliasNames: true
+      nameQuoteCharacter: '`'
+      tableAliasQuoteCharacter: '`'
+      fieldAliasQuoteCharacter: '"'
+      usingValuePlaceholders: false
+      valueHandlers: []
+    }, squel.cls.DefaultQueryBuilderOptions
 
+  'Builder base class':
+    beforeEach: ->
+      @inst = new squel.cls.BaseBuilder()
+
+    '_formatValue':
+      'string': ->
+        assert.same "'test'", @inst._formatValue('test')
+
+        @inst.options.usingValuePlaceholders = false
+        assert.same "'test'", @inst._formatValue('test')
+
+        @inst.options.usingValuePlaceholders = true
+        assert.same "test", @inst._formatValue('test')
+
+        @inst.options.usingValuePlaceholders = false
+        @inst.options.replaceSingleQuotes = true
+        assert.same "'te''st'", @inst._formatValue("te'st")
+
+        @inst.options.singleQuoteReplacement = '--'
+        assert.same "'te--st'", @inst._formatValue("te'st")
+
+        @inst.options.replaceSingleQuotes = false
+        assert.same "'te'st'", @inst._formatValue("te'st")
 
 module?.exports[require('path').basename(__filename)] = test


### PR DESCRIPTION
It adds two new settings to enable single quotes replacement for values.
In postgres the single quotes must be escaped with double single quote `''` (see http://stackoverflow.com/questions/12316953/insert-varchar-with-single-quotes-in-postgresql) 
