### PR TITLE
add setMap() as shortcut for chained .set() calls

### DIFF
--- a/squel.js
+++ b/squel.js
@@ -631,6 +631,13 @@ OTHER DEALINGS IN THE SOFTWARE.
       this.fields[field] = value;
       return this;
     };
+    
+    SetFieldBlock.prototype.setMap = function(map) {
+      for (var f in map) {
+        this.set(f, map[f])
+      }
+      return this;
+    }
 
     SetFieldBlock.prototype.buildStr = function(queryBuilder) {
       var field, fieldNames, fields, _i, _len;


### PR DESCRIPTION
I'm often working with objects and it's a little cumbersome to have to iterate through each field for a .set(), so how about a convenience function .setMap()?

I.e.
// Row would normally be built elsewhere - maybe as JSON from a client.
var row = {id: 14, name: 'test'};

squel.insert()
  .set('id', row.id)
  .set('name', row.name)

becomes:
squel.insert().setMap(row)
