### PR TITLE
Increment queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can use nested queries too:
         .set("f1", 1)
         .toString()
 
-    // UPDATE test, test2, test3 AS `a` SET test.id = 1, test2.val = 1.2, a.name = "Ram", a.email = NULL
+    // UPDATE test, test2, test3 AS `a` SET test.id = 1, test2.val = 1.2, a.name = "Ram", a.email = NULL, a.count = a.count + 1
     squel.update()
         .table("test")
         .set("test.id", 1)
@@ -104,6 +104,7 @@ You can use nested queries too:
         .table("test3","a")
         .set("a.name", "Ram")
         .set("a.email", null)
+        .set("a.count = a.count + 1")
         .toString()
 
 **INSERT**

--- a/src/squel.coffee
+++ b/src/squel.coffee
@@ -574,7 +574,7 @@ class cls.SetFieldBlock extends cls.Block
   # This will override any previously set value for the given field.
   set: (field, value) ->
     field = @_sanitizeField(field)
-    value = @_sanitizeValue(value)
+    value = @_sanitizeValue(value) if typeof value isnt 'undefined'
     @fields[field] = value
     @
 
@@ -585,7 +585,12 @@ class cls.SetFieldBlock extends cls.Block
     fields = ""
     for field in fieldNames
       fields += ", " if "" isnt fields
-      fields += "#{field} = #{@_formatValue(@fields[field])}"
+
+      value = @fields[field]
+      if typeof value is 'undefined'
+        fields += field
+      else
+        fields += "#{field} = #{@_formatValue(value)}"
 
     "SET #{fields}"
 

--- a/test/blocks.test.coffee
+++ b/test/blocks.test.coffee
@@ -494,11 +494,13 @@ test['Blocks'] =
         @inst.set('field1', 'value1')
         @inst.set('field2', 'value2')
         @inst.set('field3', 'value3')
+        @inst.set('field4')
 
         expected =
           'field1': 'value1',
           'field2': 'value2',
-          'field3': 'value3'
+          'field3': 'value3',
+          'field4': undefined
 
         assert.same expected, @inst.fields
 

--- a/test/update.test.coffee
+++ b/test/update.test.coffee
@@ -124,6 +124,11 @@ test['UPDATE builder'] =
                 toString: ->
                   assert.same @inst.toString(), 'UPDATE table `t1`, table2 SET field = 1, field2 = NULL WHERE (a = 1) ORDER BY a ASC LIMIT 2'
 
+    '>> table(table, t1).set("count = count + 1")':
+      beforeEach: -> @inst.table('table', 't1').set('count = count + 1')
+      toString: ->
+        assert.same @inst.toString(), 'UPDATE table `t1` SET count = count + 1'
+
 
   'cloning': ->
     newinst = @inst.table('students').set('field', 1).clone()


### PR DESCRIPTION
hey,

first of all, thanks for squel! i really enjoy using it.

i was wondering how to increment a field using squel, so i read through the documentation
and through the code, but couldn't find a way to do it.

``` sql
UPDATE foo SET count = count + 1 where id = 1
```

this is what i need. my problem is, that `#_formatValue` [always quotes the value](https://github.com/hiddentao/squel/blob/a203998973927f34c910ce93f4f7908d633326ae/src/squel.coffee#L240).
so, i can see three ways to support this.
1. add an `autoQuoteValues` option to disable quoting for a query
2. add a `quoteValue` option to the `#set` function
3. change `#set` to also accept a string for both the field and value like `#where`

the third option is what i instinctively tried before digging into the source and i think
it's the most elegant solution. but i can't think of a way to make it also work with
placeholders like `#where` does while supporting the current api.

here's an example of how it would look like:

``` javascript
squel.update().table('foo').set('count = count + 1').where('id = 1')
```

what do you think?
