### PR TITLE
Don't escape values for toParam()

### DIFF
--- a/src/squel.coffee
+++ b/src/squel.coffee
@@ -664,7 +664,7 @@ class cls.SetFieldBlock extends cls.AbstractSetFieldBlock
     for i in [0...@fields.length]
       str += ", " if "" isnt str
       str += "#{@fields[i]} = ?"
-      vals.push @_formatValue(@values[0][i])
+      vals.push @values[0][i]
 
     { text: "SET #{str}", values: vals }
 
@@ -699,7 +699,7 @@ class cls.InsertFieldValueBlock extends cls.AbstractSetFieldBlock
 
      for i in [0...@values.length]
       for j in [0...@values[i].length]
-        params.push @_formatValue(@values[i][j])
+        params.push @values[i][j]
         if 'string' is typeof vals[i]
           vals[i] += ', ?'           
         else 

--- a/test/blocks.test.coffee
+++ b/test/blocks.test.coffee
@@ -657,18 +657,15 @@ test['Blocks'] =
         catch err
           assert.same 'Error: set() needs to be called', err.toString()
 
-      'calls formatValue() for each field value': ->
+      'does not call formatValue() for each field value': ->
         formatValueSpy = test.mocker.stub @cls.prototype, '_formatValue', (v) -> return "[#{v}]"
 
         @inst.fields = [ 'field1', 'field2', 'field3' ]
         @inst.values = [ [ 'value1', 'value2', 'value3' ] ]
 
-        assert.same { text: 'SET field1 = ?, field2 = ?, field3 = ?', values: ['[value1]', '[value2]', '[value3]'] }, @inst.buildParam()
+        assert.same { text: 'SET field1 = ?, field2 = ?, field3 = ?', values: ['value1', 'value2', 'value3'] }, @inst.buildParam()
 
-        assert.ok formatValueSpy.calledThrice
-        assert.ok formatValueSpy.calledWithExactly 'value1'
-        assert.ok formatValueSpy.calledWithExactly 'value2'
-        assert.ok formatValueSpy.calledWithExactly 'value3'
+        assert.ok formatValueSpy.notCalled
 
 
 
@@ -734,7 +731,7 @@ test['Blocks'] =
         catch err
           assert.same 'Error: set() needs to be called', err.toString()
 
-      'calls formatValue() for each field value': ->
+      'does not call formatValue() for each field value': ->
         formatValueSpy = test.mocker.stub @cls.prototype, '_formatValue', (v) -> return "[#{v}]"
 
         @inst.fields = [ 'field1', 'field2', 'field3' ]
@@ -742,13 +739,10 @@ test['Blocks'] =
 
         assert.same { 
           text: '(field1, field2, field3) VALUES (?, ?, ?), (?, ?, ?)', 
-          values: [ '[value1]', '[value2]', '[value3]', '[value21]', '[value22]', '[value23]' ] 
+          values: [ 'value1', 'value2', 'value3', 'value21', 'value22', 'value23' ] 
         }, @inst.buildParam()
 
-        assert.same formatValueSpy.callCount, 6
-        assert.ok formatValueSpy.calledWithExactly 'value1'
-        assert.ok formatValueSpy.calledWithExactly 'value2'
-        assert.ok formatValueSpy.calledWithExactly 'value3'
+        assert.ok formatValueSpy.notCalled
 
 
 

--- a/test/insert.test.coffee
+++ b/test/insert.test.coffee
@@ -82,7 +82,7 @@ test['INSERT builder'] =
         toParam: ->
           assert.same @inst.toParam(), {
             text: 'INSERT INTO table (field, field2) VALUES (?, ?)'
-            values: [ 1, '\'str\'' ]
+            values: [ 1, 'str' ]
           }
 
       '>> set(field2, true)':
@@ -102,7 +102,7 @@ test['INSERT builder'] =
         toParam: ->
           parameterized = @inst.toParam()
           assert.same parameterized.text, 'INSERT INTO table (field, field2, field3) VALUES (?, ?, ?)'
-          assert.same parameterized.values, [1,'\'value2\'','TRUE']
+          assert.same parameterized.values, [1,'value2',true]
 
       '>> setFields({field2: \'value2\', field: true })':
         beforeEach: -> @inst.setFields({field2: 'value2', field: true })
@@ -111,7 +111,7 @@ test['INSERT builder'] =
         toParam: ->
           parameterized = @inst.toParam()
           assert.same parameterized.text, 'INSERT INTO table (field, field2) VALUES (?, ?)'
-          assert.same parameterized.values, ['TRUE', '\'value2\'']
+          assert.same parameterized.values, [true, 'value2']
 
       '>> setFieldsRows([{field2: \'value2\', field: true },{field: \'value3\', field2: 13 }]])':
         beforeEach: -> @inst.setFieldsRows([{field: 'value2', field2: true },{field: 'value3', field2: 13 }])
@@ -120,7 +120,7 @@ test['INSERT builder'] =
         toParam: ->
           parameterized = @inst.toParam()
           assert.same parameterized.text, 'INSERT INTO table (field, field2) VALUES (?, ?), (?, ?)'
-          assert.same parameterized.values, ['\'value2\'','TRUE', '\'value3\'',13]
+          assert.same parameterized.values, ['value2',true, 'value3',13]
 
     '>> into(table).setFieldsRows([{field1: 13, field2: \'value2\'},{field1: true, field3: \'value4\'}])': ->
       assert.throws (=> @inst.into('table').setFieldsRows([{field1: 13, field2: 'value2'},{field1: true, field3: 'value4'}]).toString()), 'All fields in subsequent rows must match the fields in the first row'

--- a/test/update.test.coffee
+++ b/test/update.test.coffee
@@ -87,7 +87,7 @@ test['UPDATE builder'] =
         toParam: ->
           assert.same @inst.toParam(), {
             text: 'UPDATE table `t1` SET field = ?, field2 = ?'
-            values: [1, '\'str\'']
+            values: [1, 'str']
           }
 
       '>> setFields({field2: \'value2\', field3: true })':


### PR DESCRIPTION
SQL client libraries like node-postgres expect to perform their own
escaping/formatting when given parameterized queries. Remove the format
call when doing toParam() so that query parameters are not
escaped/formatted twice.
