### PR TITLE
MySQL InsertFieldValueBlock should extend AbstractSetFieldBlock

### DIFF
--- a/squel.js
+++ b/squel.js
@@ -1651,7 +1651,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
       return InsertFieldValueBlock;
 
-    })(cls.SetFieldBlock);
+    })(cls.AbstractSetFieldBlock);
   };
 
 }).call(this);

--- a/src/mysql.coffee
+++ b/src/mysql.coffee
@@ -29,7 +29,7 @@ squel.flavours['mysql'] = ->
   cls = squel.cls
 
   # (INSERT INTO) ... field ... value
-  class cls.InsertFieldValueBlock extends cls.SetFieldBlock
+  class cls.InsertFieldValueBlock extends cls.AbstractSetFieldBlock
     constructor: (options) ->
       super options
       @fields = {}


### PR DESCRIPTION
Fixes #80. I'm not sure if it should be extending squel's InsertFieldValueBlock but this at least gets this sample working:

``` js
var squel = require('squel').useFlavour('mysql');
var query = squel.insert()
        .into("students")
        .setFieldsRows([
          { name: "Thomas", age: 29 },
          { name: "Jane", age: 31 }
        ]);
console.log(query->toString());
```
