### PR TITLE
Enable limit to be 0

### DIFF
--- a/src/squel.coffee
+++ b/src/squel.coffee
@@ -1307,7 +1307,7 @@ _buildSquel = ->
 
 
     buildStr: (queryBuilder) ->
-      if @limits then "LIMIT #{@limits}" else ""
+      if @limits || @limits == 0 then "LIMIT #{@limits}" else ""
 
 
 


### PR DESCRIPTION
It is currently not possible to supply a limit of 0, since the assertion is falsy, and `0 == false` is true. 

```
squel.select().from('myTable').limit(0)
```

**Before:**
'SELECT * FROM myTable'

**After:**
'SELECT * FROM myTable LIMIT 0'