### PR TITLE
Add support for LATERAL keyword

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -495,6 +495,14 @@ function _buildSquel(flavour = null) {
       return str;
     }
 
+    _applyLateralFormatting(str, lateral = false) {
+      if (str && typeof str === 'string' && lateral) {
+        return `LATERAL ${str}`;
+      }
+
+      return str;
+    }
+
 
     /** 
      * Build given string and its corresponding parameter values into 
@@ -1108,6 +1116,7 @@ function _buildSquel(flavour = null) {
     # Internally this method simply calls the field() method of this block to add each individual field.
     #
     # options.ignorePeriodsForFieldNameQuotes - whether to ignore period (.) when automatically quoting the field name
+    # options.lateral - whether to prefix a subquery with the LATERAL keyword
     */
     fields (_fields, options = {}) {
       if (_isArray(_fields)) {
@@ -1173,7 +1182,7 @@ function _buildSquel(flavour = null) {
             buildParameterized: buildParameterized,
           });
 
-          totalStr += ret.text;
+          totalStr += this._applyLateralFormatting(ret.text, options && options.lateral);
           totalValues.push(...ret.values);
         }
 
@@ -1703,9 +1712,11 @@ function _buildSquel(flavour = null) {
     # an expression builder then it gets evaluated straight away.
     #
     # 'type' must be either one of INNER, OUTER, LEFT or RIGHT. Default is 'INNER'.
-    #
+    # 
+    # 'options' is an object with additional options that can be applied to the join:
+    # * 'lateral' will apply the LATERAL keyword to the join
     */
-    join (table, alias = null, condition = null, type = 'INNER') {
+    join (table, alias = null, condition = null, type = 'INNER', options = {}) {
       table = this._sanitizeTable(table, true);
       alias = alias ? this._sanitizeTableAlias(alias) : alias;
       condition = condition ? this._sanitizeExpression(condition) : condition;
@@ -1715,31 +1726,32 @@ function _buildSquel(flavour = null) {
         table: table,
         alias: alias,
         condition: condition,
+        options: options
       });
     }
 
-    left_join (table, alias = null, condition = null) {
-      this.join(table, alias, condition, 'LEFT');
+    left_join (table, alias = null, condition = null, options = {}) {
+      this.join(table, alias, condition, 'LEFT', options);
     }
 
-    right_join (table, alias = null, condition = null) {
-      this.join(table, alias, condition, 'RIGHT');
+    right_join (table, alias = null, condition = null, options = {}) {
+      this.join(table, alias, condition, 'RIGHT', options);
     }
 
-    outer_join (table, alias = null, condition = null) {
-      this.join(table, alias, condition, 'OUTER');
+    outer_join (table, alias = null, condition = null, options = {}) {
+      this.join(table, alias, condition, 'OUTER', options);
     }
 
-    left_outer_join (table, alias = null, condition = null) {
-      this.join(table, alias, condition, 'LEFT OUTER');
+    left_outer_join (table, alias = null, condition = null, options = {}) {
+      this.join(table, alias, condition, 'LEFT OUTER', options);
     }
 
-    full_join (table, alias = null, condition = null) {
-      this.join(table, alias, condition, 'FULL');
+    full_join (table, alias = null, condition = null, options = {}) {
+      this.join(table, alias, condition, 'FULL', options);
     }
 
-    cross_join (table, alias = null, condition = null) {
-      this.join(table, alias, condition, 'CROSS');
+    cross_join (table, alias = null, condition = null, options = {}) {
+      this.join(table, alias, condition, 'CROSS', options);
     }
 
 
@@ -1747,7 +1759,7 @@ function _buildSquel(flavour = null) {
       let totalStr = "",  
         totalValues = [];
 
-      for (let {type, table, alias, condition} of this._joins) {
+      for (let {type, table, alias, condition, options: joinOptions} of this._joins) {
         totalStr = _pad(totalStr, this.options.separator);
 
         let tableStr;
@@ -1763,6 +1775,8 @@ function _buildSquel(flavour = null) {
         } else {
           tableStr = this._formatTableName(table);
         }
+
+        tableStr = this._applyLateralFormatting(tableStr, joinOptions && joinOptions.lateral);
 
         totalStr += `${type} JOIN ${tableStr}`;
 


### PR DESCRIPTION
This adds support for the LATERAL keyword on queries. For details see http://www.postgresql.org/docs/9.5/static/queries-table-expressions.html#QUERIES-LATERAL.

I tried to implement this such that it fits the current structure, but not sure if my solution is what you would have in mind.