### PR TITLE
.setFields with 'exclude' option with an array of fields to exclude

### DIFF
--- a/squel.js
+++ b/squel.js
@@ -1706,6 +1706,16 @@ function _buildSquel() {
       value: function _setFields(fields) {
         var valueOptions = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
+        if (Array.isArray(valueOptions.exclude)) {
+          fields = Object.keys(fields);
+          .reduce(function (result, field) {
+            if (valueOptions.exclude.indexOf(field) === -1) {
+              result[field] = fields[field];
+            }
+            return result;
+          }, {})
+        }
+
         if ((typeof fields === 'undefined' ? 'undefined' : _typeof(fields)) !== 'object') {
           throw new Error("Expected an object but got " + (typeof fields === 'undefined' ? 'undefined' : _typeof(fields)));
         }


### PR DESCRIPTION
This is for `setFields` as part of `squel.update()` chaining.
This is useful for when I have an object I am working with, which corresponds to some SQL table schema. 
Eventually we would want to do:
``
squel.update().setFields(obj).toString()
``
_but_ with the option of excluding some fields from `obj`. 
Obviously, we would prefer a more convenient way than creating an object with a subset of fields every time we would want such functionality.
So eventually we would have `squel.update().setFields(obj, {exclude: ['some_field']})`
