### PR TITLE
Add support for REPLACE statement on Mysql

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2091,12 +2091,7 @@ function _buildSquel(flavour = null) {
       super(options, blocks);
     }
   }
-
-  // Dummy REPLACE query builder
-  cls.Replace = function(options, blocks){
-    throw new Error(`Only available on Mysql`);
-  }
-
+  
 
   let _squel = {
     VERSION: '<<VERSION_STRING>>',
@@ -2115,9 +2110,6 @@ function _buildSquel(flavour = null) {
     },
     insert: function(options, blocks) {
       return new cls.Insert(options, blocks);
-    },
-    replace: function(options, blocks) {
-      return new cls.Replace(options, blocks);
     },
     delete: function(options, blocks) {
       return new cls.Delete(options, blocks);

--- a/src/core.js
+++ b/src/core.js
@@ -2092,6 +2092,11 @@ function _buildSquel(flavour = null) {
     }
   }
 
+  // Dummy REPLACE query builder
+  cls.Replace = function(options, blocks){
+    throw new Error(`Only available on Mysql`);
+  }
+
 
   let _squel = {
     VERSION: '<<VERSION_STRING>>',
@@ -2110,6 +2115,9 @@ function _buildSquel(flavour = null) {
     },
     insert: function(options, blocks) {
       return new cls.Insert(options, blocks);
+    },
+    replace: function(options, blocks) {
+      return new cls.Replace(options, blocks);
     },
     delete: function(options, blocks) {
       return new cls.Delete(options, blocks);

--- a/src/mysql.js
+++ b/src/mysql.js
@@ -78,5 +78,9 @@ squel.flavours['mysql'] = function(_squel) {
   }
 
 
+  _squel.replace = function(options, blocks){
+      return new cls.Replace(options, blocks);
+  }
+
 };
 

--- a/src/mysql.js
+++ b/src/mysql.js
@@ -63,6 +63,20 @@ squel.flavours['mysql'] = function(_squel) {
     }
   }
 
+  // REPLACE query builder.
+  cls.Replace = class extends cls.QueryBuilder {
+    constructor (options, blocks = null) {
+      blocks = blocks || [
+        new cls.StringBlock(options, 'REPLACE'),
+        new cls.IntoTableBlock(options),
+        new cls.InsertFieldValueBlock(options),
+        new cls.InsertFieldsFromQueryBlock(options),
+      ];
+
+      super(options, blocks);
+    }
+  }
+
 
 };
 

--- a/test/mysql.test.coffee
+++ b/test/mysql.test.coffee
@@ -106,4 +106,23 @@ test['MySQL flavour'] =
         }
 
 
+  'REPLACE builder':
+    beforeEach: -> @inst = squel.replace()
+
+    '>> into(table).set(field, 1).set(field1, 2)':
+      beforeEach: ->
+        @inst
+          .into('table')
+          .set('field', 1)
+          .set('field1', 2)
+      toString: ->
+        assert.same @inst.toString(), 'REPLACE INTO table (field, field1) VALUES (1, 2)'
+
+      toParam: ->
+        assert.same @inst.toParam(), {
+          text: 'REPLACE INTO table (field, field1) VALUES (?, ?)'
+          values: [1, 2]
+        }
+
+
 module?.exports[require('path').basename(__filename)] = test


### PR DESCRIPTION
Add support to REPLACE statement to Mysql flavour. It can be used like the `squel.insert()` function:

`squel = squel.useFlavour('mysql');`
`squel.replace().into(table).set(field, value)...`

In case that you're using other flavour, it throws an error.

More info: [http://dev.mysql.com/doc/refman/5.7/en/replace.html]