### PR TITLE
Support passing a string to use for order direction

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1623,17 +1623,22 @@ function _buildSquel(flavour = null) {
     /**
     # Add an ORDER BY transformation for the given field in the given order.
     #
-    # To specify descending order pass false for the 'asc' parameter.
+    # To specify descending order pass false for the 'dir' parameter.
     */
-    order (field, asc, ...values) {
+    order (field, dir, ...values) {
       field = this._sanitizeField(field);
 
-      asc = (asc === undefined) ? true : asc;
-      asc = (asc !== null) ? !!asc : asc;
+      if (!(typeof dir === 'string')) {
+        if (dir === undefined) {
+          dir = 'ASC' // Default to asc
+        } else if (dir !== null) {
+          dir = dir ? 'ASC' : 'DESC'; // Convert truthy to asc
+        }
+      }
 
       this._orders.push({
         field: field,
-        dir: asc,   
+        dir: dir,   
         values: values,
       });
     }
@@ -1653,7 +1658,7 @@ function _buildSquel(flavour = null) {
         totalValues.push(...ret.values);
 
         if (dir !== null) {
-          totalStr += ` ${dir ? 'ASC' : 'DESC'}`;
+          totalStr += ` ${dir}`;
         }
       }
 

--- a/test/blocks.test.coffee
+++ b/test/blocks.test.coffee
@@ -1178,17 +1178,17 @@ test['Blocks'] =
         expected = [
           {
             field: 'field1',
-            dir: true
+            dir: 'ASC'
             values: []
           },
           {
             field: 'field2',
-            dir: false
+            dir: 'DESC'
             values: []
           },
           {
             field: 'field3',
-            dir: true
+            dir: 'ASC'
             values: []
           }
         ]
@@ -1202,12 +1202,12 @@ test['Blocks'] =
 
         assert.ok sanitizeFieldSpy.calledWithExactly 'field1'
 
-        assert.same @inst._orders, [ { field: '_f', dir: true, values: [] } ]
+        assert.same @inst._orders, [ { field: '_f', dir: 'ASC', values: [] } ]
 
       'saves additional values': ->
         @inst.order('field1', false, 1.2, 4)
 
-        assert.same @inst._orders, [ { field: 'field1', dir: false, values: [1.2, 4] } ]
+        assert.same @inst._orders, [ { field: 'field1', dir: 'DESC', values: [1.2, 4] } ]
 
 
     '_toParamString()':

--- a/test/select.test.coffee
+++ b/test/select.test.coffee
@@ -201,6 +201,11 @@ test['SELECT builder'] =
                   toString: ->
                     assert.same @inst.toString(), 'SELECT DISTINCT field1 AS "fa1", field2 FROM table, table2 `alias2` INNER JOIN other_table WHERE (a = 1) GROUP BY field, field2 ORDER BY a'
 
+                '>> order(a, \'asc nulls last\')':
+                  beforeEach: -> @inst.order('a', 'asc nulls last')
+                  toString: ->
+                    assert.same @inst.toString(), 'SELECT DISTINCT field1 AS "fa1", field2 FROM table, table2 `alias2` INNER JOIN other_table WHERE (a = 1) GROUP BY field, field2 ORDER BY a asc nulls last'
+
                 '>> order(a, true)':
                   beforeEach: -> @inst.order('a', true)
                   toString: ->


### PR DESCRIPTION
This fixes issue #237 as suggested here https://github.com/hiddentao/squel/issues/237#issuecomment-232858930