### PR TITLE
Support .onConflict() with optional conflict field(s) [Postgres]

### DIFF
--- a/test/postgres.test.coffee
+++ b/test/postgres.test.coffee
@@ -48,6 +48,21 @@ test['Postgres flavour'] =
       toString: ->
         assert.same @inst.toString(), 'INSERT INTO table (field, field2) VALUES (1, 2) ON CONFLICT (field) DO NOTHING'
 
+    '>> into(table).set(field, 1).set(field,2).onConflict(["field1", "field2"], {field3:3})':
+      beforeEach: -> @inst.into('table').set('field', 1).set('field2', 2).onConflict(['field1', 'field2'], {field3: 3})
+      toString: ->
+        assert.same @inst.toString(), 'INSERT INTO table (field, field2) VALUES (1, 2) ON CONFLICT (field1, field2) DO UPDATE SET field3 = 3'
+
+    '>> into(table).set(field, 1).set(field,2).onConflict(["field1", "field2"])':
+      beforeEach: -> @inst.into('table').set('field', 1).set('field2', 2).onConflict('field')
+      toString: ->
+        assert.same @inst.toString(), 'INSERT INTO table (field, field2) VALUES (1, 2) ON CONFLICT (field) DO NOTHING'
+
+    '>> into(table).set(field, 1).set(field,2).onConflict()':
+      beforeEach: -> @inst.into('table').set('field', 1).set('field2', 2).onConflict()
+      toString: ->
+        assert.same @inst.toString(), 'INSERT INTO table (field, field2) VALUES (1, 2) ON CONFLICT DO NOTHING'
+
     '>> into(table).set(field, 1).returning("*")':
       beforeEach: -> @inst.into('table').set('field', 1).returning('*')
       toString: ->

--- a/test/postgres.test.coffee
+++ b/test/postgres.test.coffee
@@ -48,12 +48,12 @@ test['Postgres flavour'] =
       toString: ->
         assert.same @inst.toString(), 'INSERT INTO table (field, field2) VALUES (1, 2) ON CONFLICT (field) DO NOTHING'
 
-    '>> into(table).set(field, 1).set(field,2).onConflict(["field1", "field2"], {field3:3})':
-      beforeEach: -> @inst.into('table').set('field', 1).set('field2', 2).onConflict(['field1', 'field2'], {field3: 3})
+    '>> into(table).set(field, 1).set(field,2).onConflict(["field", "field2"], {field3:3})':
+      beforeEach: -> @inst.into('table').set('field', 1).set('field2', 2).onConflict(['field', 'field2'], {field3: 3})
       toString: ->
-        assert.same @inst.toString(), 'INSERT INTO table (field, field2) VALUES (1, 2) ON CONFLICT (field1, field2) DO UPDATE SET field3 = 3'
+        assert.same @inst.toString(), 'INSERT INTO table (field, field2) VALUES (1, 2) ON CONFLICT (field, field2) DO UPDATE SET field3 = 3'
 
-    '>> into(table).set(field, 1).set(field,2).onConflict(["field1", "field2"])':
+    '>> into(table).set(field, 1).set(field,2).onConflict(["field", "field2"])':
       beforeEach: -> @inst.into('table').set('field', 1).set('field2', 2).onConflict('field')
       toString: ->
         assert.same @inst.toString(), 'INSERT INTO table (field, field2) VALUES (1, 2) ON CONFLICT (field) DO NOTHING'


### PR DESCRIPTION
This is to support a more varied use of `.onConflict` that PostgreSQL's `ON CONFLICT`
expression supports.

E.g. these are all ways to do conflict statements (currently only the second one is
supported).
```sql
INSERT INTO table_name (foo, bar) VALUES (1, 2) ON CONFLICT DO NOTHING;
INSERT INTO table_name (foo, bar) VALUES (1, 2) ON CONFLICT (foo) DO NOTHING;
INSERT INTO table_name (foo, bar) VALUES (1, 2) ON CONFLICT (foo, bar) DO NOTHING;
```
After this change, Squel will support all 3 cases
```js
// set up your insert...

insert.onConflict()                    // case 1
insert.onConflict('foo')               // case 2
insert.onConflict(['foo', 'bar'])      // case 3
```

**NOTE**: This change doesn't include compiled `dist/` files yet - that needs to happen before this merges into master and is deployed. I'll do that if you agree that this is a good change; I just figure it's easier to review without artifacts.