### PR TITLE
Allow squel to be used without values for the ? params.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -687,6 +687,15 @@ function _buildSquel(flavour = null) {
 
 
     /**
+     * Get the expression string, ignoring values, this will only return the query.
+     * @return {String}
+     */
+    toQuery (options = {}) {
+      return this.toParam(options).text;
+    }
+
+
+    /**
      * Get the parameterized expression string.
      * @return {Object}
      */

--- a/src/core.js
+++ b/src/core.js
@@ -678,7 +678,9 @@ function _buildSquel(flavour = null) {
 
 
     /**
-     * Get the expression string.
+     * Get the expression string, return just the plain query if the user doesn't want squel to replace/escape
+     * the values, the queries will just return 'select * from table where a = ?'
+     * instead of 'select * from table where a = undefined'
      * @return {String}
      */
     toString (options = {}) {


### PR DESCRIPTION
let sql = squel
  .select({withoutValues:true})
  .from('table')
  .where('a=?').toQuery();

//  This returns a string like: 'SELECT * FROM coco WHERE (a=?)' that will be ready for the DB drivers to just replace and sanitize values.