### PR TITLE
Add GetFieldBlock methods to remove fields from final result set

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1209,6 +1209,37 @@ function _buildSquel(flavour = null) {
       });
     }
 
+    /**
+    # Remove the given field from the final result set.
+    # 
+    */
+    removeField (field) {
+      field = this._sanitizeField(field);
+
+      // search by alias
+      let index = this._fields.findIndex((f) => {
+        return f.alias === field;
+      });
+
+      if (index === -1) {
+        // search by name
+        index = this._fields.findIndex((f) => {
+          return f.name === field;
+        });
+      }
+
+      if (index !== -1) {
+        this._fields.splice(index, 1);
+      }
+    }
+
+    /**
+    # Remove all fields from the final result set.
+    # 
+    */
+    removeAllFields () {
+      this._fields = [];
+    }
 
     _toParamString (options = {}) {
       let { queryBuilder, buildParameterized } = options;

--- a/test/blocks.test.coffee
+++ b/test/blocks.test.coffee
@@ -499,6 +499,35 @@ test['Blocks'] =
 
         assert.same expected, @inst._fields
 
+      'remove inputs': -> 
+        @inst.field('field1')
+        @inst.field('field2', 'alias2')
+        @inst.field('field1', 'alias1')
+
+        @inst.removeField('alias1')
+        @inst.removeField('field2')
+
+        expected = [
+          {
+          name: 'field1',
+          alias: null
+          options: {},
+          }
+        ]
+
+        assert.same expected, @inst._fields
+
+      'remove all inputs': -> 
+        @inst.field('field1')
+        @inst.field('field2', 'alias2')
+        @inst.field('field1', 'alias1')
+
+        @inst.removeAllFields()
+
+        expected = []
+
+        assert.same expected, @inst._fields
+
     'field() - discard duplicates':
       'saves inputs': ->
         @inst.field('field1')


### PR DESCRIPTION
Example : 

```
const squel = require('squel');

const sql = squel.select();

sql.field('field1')
   .field('field2', 'alias2')
   .field('field1', 'alias1')
   .from('table1');

/* SELECT field1, field2 as alias2, field1 as alias1 FROM table1; */

sql.removeField('alias1')
   .removeField('field2');

/* SELECT field1 FROM table1; */

sql.removeAllFields();

/* SELECT * FROM table1; */
```
