### PR TITLE
ci: make npm publish step resumable after a failed publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,24 @@ jobs:
           PREV=$(node -p "require('./package.json').version")
           bunx commit-and-tag-version
           NEXT=$(node -p "require('./package.json').version")
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
           if [ "$PREV" = "$NEXT" ]; then
             echo "released=false" >> "$GITHUB_OUTPUT"
-            echo "No release-worthy changes since last tag; skipping push and publish."
+            echo "No release-worthy changes since last tag; will only publish if ${NEXT} is missing from npm."
           else
             echo "released=true" >> "$GITHUB_OUTPUT"
-            echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check if current version is already on npm
+        id: npm-check
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          if npm view "squel@${VERSION}" version >/dev/null 2>&1; then
+            echo "needs_publish=false" >> "$GITHUB_OUTPUT"
+            echo "squel@${VERSION} already on npm; skipping publish."
+          else
+            echo "needs_publish=true" >> "$GITHUB_OUTPUT"
+            echo "squel@${VERSION} not on npm yet; will publish."
           fi
 
       - name: Push release commit and tag
@@ -90,5 +102,5 @@ jobs:
         run: git push --follow-tags origin HEAD:master
 
       - name: Publish to npm
-        if: steps.bump.outputs.released == 'true'
+        if: steps.npm-check.outputs.needs_publish == 'true'
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Gate the `Publish to npm` step on whether the current `package.json` version is actually on npm, not on whether this run did a version bump.
- After a failed publish (e.g. the current situation: `v6.0.1` is tagged on master but missing from npm), a `workflow_dispatch` on the same commit will now fill the gap instead of being skipped because `commit-and-tag-version` finds nothing new to bump.
- Idempotent: if the current version is already on npm, both push and publish are skipped.

Needs npm Trusted Publisher configured for `squel` before it will actually succeed — after that, `gh workflow run release.yml` publishes `6.0.1`.

## Test plan

- [ ] Merge this PR.
- [ ] Configure npm Trusted Publisher at https://www.npmjs.com/package/squel/access (org `hiddentao`, repo `squel`, workflow `release.yml`).
- [ ] `gh workflow run release.yml --ref master`.
- [ ] Confirm the dispatched run: `Bump…` sets `released=false`; `Check if current version is already on npm` sets `needs_publish=true`; `Push release commit and tag` is skipped; `Publish to npm` runs green.
- [ ] `npm view squel version` returns `6.0.1`.