### PR TITLE
ci: only bump version when release-worthy commits exist since last tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,14 +75,26 @@ jobs:
         id: bump
         run: |
           PREV=$(node -p "require('./package.json').version")
-          bunx commit-and-tag-version
-          NEXT=$(node -p "require('./package.json').version")
-          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
-          if [ "$PREV" = "$NEXT" ]; then
-            echo "released=false" >> "$GITHUB_OUTPUT"
-            echo "No release-worthy changes since last tag; will only publish if ${NEXT} is missing from npm."
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+          RUN_BUMP="false"
+          if [ -z "$LAST_TAG" ]; then
+            RUN_BUMP="true"
+          elif git log "${LAST_TAG}..HEAD" --pretty=format:'%s%n%b' | grep -qE '^(feat|fix|perf)[(!:]|^BREAKING[- ]CHANGE:'; then
+            RUN_BUMP="true"
+          fi
+          if [ "$RUN_BUMP" = "true" ]; then
+            bunx commit-and-tag-version
+            NEXT=$(node -p "require('./package.json').version")
+            echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+            if [ "$PREV" = "$NEXT" ]; then
+              echo "released=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "released=true" >> "$GITHUB_OUTPUT"
+            fi
           else
-            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "version=$PREV" >> "$GITHUB_OUTPUT"
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "No feat/fix/perf/BREAKING commits since ${LAST_TAG}; skipping bump. Will only publish if ${PREV} is missing from npm."
           fi
 
       - name: Check if current version is already on npm


### PR DESCRIPTION
## Summary

- `commit-and-tag-version` patch-bumps by default even when no `feat:` / `fix:` / `perf:` / `BREAKING CHANGE` commits are present, so each `workflow_dispatch` on a clean master was inventing a new version (we went `6.0.2 → 6.0.3` with zero new commits).
- Detect release-worthy commits with `git log $LAST_TAG..HEAD` before invoking `commit-and-tag-version`. If none, emit the current version as the step output so the downstream `Check if current version is already on npm` step can still drive a resumable publish.
- Net effect: `workflow_dispatch` on a clean master is a no-op (green run, no new tag, no new commit, no publish). Pushes with `feat:`/`fix:`/`perf:`/`BREAKING` still bump and release normally.

## Test plan

- [ ] Merge PR.
- [ ] `gh workflow run release.yml --ref master` on clean master — run goes green with "No feat/fix/perf/BREAKING commits since v6.0.3; skipping bump", push + publish both skipped (once `6.0.3` is on npm) or publish filling the gap (until it is).
- [ ] Next real `fix:` commit to master still triggers a bump to `6.0.4`, push, publish.