### PR TITLE
fix(mssql): add support for .having() in Select builder

### DIFF
--- a/src/mssql.ts
+++ b/src/mssql.ts
@@ -207,6 +207,7 @@ squel.flavours.mssql = (_squel: Squel) => {
         new cls.JoinBlock(options),
         new cls.WhereBlock(options),
         new cls.GroupByBlock(options),
+        new cls.HavingBlock(options),
         new cls.OrderByBlock(options),
         limitOffsetTopBlock.OFFSET(),
         limitOffsetTopBlock.LIMIT(),

--- a/tests/mssql.test.ts
+++ b/tests/mssql.test.ts
@@ -115,6 +115,18 @@ describe("MSSQL flavour", () => {
         )
       })
     })
+
+    describe(">> from(table).group(field).having(COUNT(*) > ?, 1)", () => {
+      beforeEach(() => {
+        sel.from("table").group("field").having("COUNT(*) > ?", 1)
+      })
+
+      it("toString", () => {
+        expect(sel.toString()).toBe(
+          "SELECT * FROM table GROUP BY field HAVING (COUNT(*) > 1)",
+        )
+      })
+    })
   })
 
   describe("INSERT builder", () => {


### PR DESCRIPTION
## Description
This PR fixes an issue where the `.having()` method was not available when using the MSSQL flavor of Squel. The `HavingBlock` was missing from the `Select` query builder blocks in the MSSQL implementation.

## Changes
- Added `HavingBlock` to the `Select` builder in `src/mssql.ts`.
- Added a new test case in `tests/mssql.test.ts` to verify `.having()` support for MSSQL.

## Verification
- Ran `bun test` (all 608 tests passed).
- Verified with `bun run check`, `bun run typecheck`, and `bun run build`.
