### PR TITLE
feat(postgres): support for `DELETE ... USING`

### DIFF
--- a/src/postgres.ts
+++ b/src/postgres.ts
@@ -141,6 +141,16 @@ squel.flavours.postgres = (_squel: Squel) => {
     }
   }
 
+  cls.UsingBlock = class extends cls.AbstractTableBlock {
+    constructor(options: any) {
+      super({ ...options, prefix: "USING" })
+    }
+
+    using(table: unknown, alias: string | null = null): void {
+      this._table(table, alias)
+    }
+  }
+
   cls.DistinctOnBlock = class extends cls.Block {
     _useDistinct = false
     _distinctFields: any[]
@@ -230,6 +240,7 @@ squel.flavours.postgres = (_squel: Squel) => {
         new cls.StringBlock(options, "DELETE"),
         new cls.TargetTableBlock(options),
         new cls.FromTableBlock({ ...options, singleTable: true }),
+        new cls.UsingBlock(options),
         new cls.JoinBlock(options),
         new cls.WhereBlock(options),
         new cls.OrderByBlock(options),

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,6 +198,7 @@ export interface Insert extends QueryBuilder {
 export interface Delete extends QueryBuilder {
   target(table: string): this
   from(table: string, alias?: string): this
+  using?(table: string, alias?: string): this
   where(condition: Conditional, ...values: unknown[]): this
   order(
     field: string,

--- a/tests/postgres.test.ts
+++ b/tests/postgres.test.ts
@@ -318,6 +318,49 @@ describe("Postgres flavour", () => {
         })
       })
     })
+
+    describe('>> from(table).using(other_table).where("field = ?")', () => {
+      beforeEach(() => {
+        del.from("table").using("other_table").where("field = ?", 1)
+      })
+
+      it("toString", () => {
+        expect(del.toString()).toBe(
+          "DELETE FROM table USING other_table WHERE (field = 1)",
+        )
+      })
+
+      it("toParam", () => {
+        expect(del.toParam()).toEqual({
+          text: "DELETE FROM table USING other_table WHERE (field = $1)",
+          values: [1],
+        })
+      })
+    })
+
+    describe('>> from(table).using(other_table, alias).where("field = 1")', () => {
+      beforeEach(() => {
+        del.from("table").using("other_table", "ot").where("field = 1")
+      })
+
+      it("toString", () => {
+        expect(del.toString()).toBe(
+          "DELETE FROM table USING other_table AS ot WHERE (field = 1)",
+        )
+      })
+    })
+
+    describe(">> from(table).using(t1).using(t2).where(...)", () => {
+      beforeEach(() => {
+        del.from("table").using("t1").using("t2").where("t1.id = table.id")
+      })
+
+      it("toString", () => {
+        expect(del.toString()).toBe(
+          "DELETE FROM table USING t1, t2 WHERE (t1.id = table.id)",
+        )
+      })
+    })
   })
 
   describe("SELECT builder", () => {


### PR DESCRIPTION
Implement `squel.delete().using(...)` in the Postgres flavor

Postgres [supports](https://www.postgresql.org/docs/current/sql-delete.html) the extremely handy `USING` clause for `DELETE`, similar to `UPDATE <table> FROM <otherTable>`.

There seems to be no precedent for flavor-specific type annotations, so I just went with marking it as optional in the `Delete` interface. Attempting to use it with another dialect with cause a runtime error of `TypeError: del.using is not a function`.