### PR TITLE
feat(core): implement `squel.select().for(str)`

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1379,6 +1379,26 @@ function _buildSquel(flavour: Flavour | null = null): Squel {
     }
   }
 
+  cls.ForBlock = class extends cls.Block {
+    _forStr: string | null
+
+    constructor(options?: QueryBuilderOptions) {
+      super(options)
+      this._forStr = null
+    }
+
+    for(str: string): void {
+      this._forStr = str
+    }
+
+    _toParamString(): ParamString {
+      return {
+        text: this._forStr !== null ? `FOR ${this._forStr}` : "",
+        values: [],
+      }
+    }
+  }
+
   cls.QueryBuilder = class extends cls.BaseBuilder {
     blocks: any[];
     [methodName: string]: any
@@ -1484,6 +1504,7 @@ function _buildSquel(flavour: Flavour | null = null): Squel {
         new cls.LimitBlock(options),
         new cls.OffsetBlock(options),
         new cls.UnionBlock(options),
+        new cls.ForBlock(options),
       ]
       super(options, blocks)
     }

--- a/src/postgres.ts
+++ b/src/postgres.ts
@@ -186,6 +186,7 @@ squel.flavours.postgres = (_squel: Squel) => {
         new cls.LimitBlock(options),
         new cls.OffsetBlock(options),
         new cls.UnionBlock(options),
+        new cls.ForBlock(options),
       ]
       super(options, blocks)
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,7 @@ export interface Select extends QueryBuilder {
   ): this
   union(table: Joinable, type?: string): this
   union_all(table: Joinable): this
+  for(str: string): this
   function(str: string, ...values: unknown[]): this
   with?(alias: string, table: QueryBuilder): this
 }
@@ -275,6 +276,7 @@ export interface ClsRegistry {
   OrderByBlock: new (options?: QueryBuilderOptions) => BaseBuilder
   JoinBlock: new (options?: QueryBuilderOptions) => BaseBuilder
   UnionBlock: new (options?: QueryBuilderOptions) => BaseBuilder
+  ForBlock: new (options?: QueryBuilderOptions) => BaseBuilder
   QueryBuilder: new (
     options?: QueryBuilderOptions,
     blocks?: unknown[],

--- a/tests/select.test.ts
+++ b/tests/select.test.ts
@@ -921,5 +921,65 @@ describe("SELECT builder", () => {
         })
       })
     })
+
+    describe("FOR clause", () => {
+      describe(">> from(table).for('UPDATE')", () => {
+        beforeEach(() => {
+          inst.from("table").for("UPDATE")
+        })
+
+        it("toString", () => {
+          expect(inst.toString()).toBe("SELECT * FROM table FOR UPDATE")
+        })
+
+        it("toParam", () => {
+          expect(inst.toParam()).toEqual({
+            text: "SELECT * FROM table FOR UPDATE",
+            values: [],
+          })
+        })
+      })
+
+      describe(">> from(table).where(field = ?).for('UPDATE SKIP LOCKED')", () => {
+        beforeEach(() => {
+          inst.from("table").where("id = ?", 1).for("UPDATE SKIP LOCKED")
+        })
+
+        it("toString", () => {
+          expect(inst.toString()).toBe(
+            "SELECT * FROM table WHERE (id = 1) FOR UPDATE SKIP LOCKED",
+          )
+        })
+
+        it("toParam", () => {
+          expect(inst.toParam()).toEqual({
+            text: "SELECT * FROM table WHERE (id = ?) FOR UPDATE SKIP LOCKED",
+            values: [1],
+          })
+        })
+      })
+
+      describe(">> from(table).for('UPDATE OF table NOWAIT')", () => {
+        beforeEach(() => {
+          inst.from("table").for("UPDATE OF table NOWAIT")
+        })
+
+        it("toString", () => {
+          expect(inst.toString()).toBe(
+            "SELECT * FROM table FOR UPDATE OF table NOWAIT",
+          )
+        })
+      })
+
+      describe(">> from(table) [no for() call]", () => {
+        beforeEach(() => {
+          inst.from("table")
+        })
+
+        it("toString omits FOR clause", () => {
+          expect(inst.toString()).toBe("SELECT * FROM table")
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
Add support for `squel.select().for(str)` so that we can generate `SELECT FROM table FOR UPDATE`. This is similar to hiddentao/squel#361 but I think it's better to only hardcode the `FOR` keyword so that we can support all the extensions that different SQL engines, eg.:

* `FOR UPDATE` (SQL standard)
* `FOR NO KEY UPDATE` 
* `FOR SHARE` 
* `FOR UPDATE NOWAIT`
* `FOR UPDATE SKIP LOCKED`
* `FOR UPDATE OF table_name`