### PR TITLE
feat(mssql): add support for CROSS APPLY and OUTER APPLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,24 @@ squel.useFlavour("mssql")
 // INSERT INTO users (name) OUTPUT INSERTED.id VALUES ('John')
 ```
 
+#### CROSS/OUTER APPLY (MSSQL)
+
+Provides `CROSS APPLY` and `OUTER APPLY` support for the MSSQL flavour:
+
+```javascript
+// MSSQL CROSS/OUTER APPLY
+squel.useFlavour("mssql")
+    .select()
+    .from("table1")
+    .cross_apply("table2", "t2")
+    .outer_apply(
+        squel.select().from("bar").where("bar.id = table1.id"),
+        "s"
+    )
+    .toString()
+// SELECT * FROM table1 CROSS APPLY table2 t2 OUTER APPLY (SELECT * FROM bar WHERE (bar.id = table1.id)) s
+```
+
 ## Non-standard SQL flavours
 
 Squel supports the standard SQL commands and reserved words. A number of database engines provide their own non-standard commands; Squel makes it easy to load different "flavours" of SQL that augment the core builders with engine-specific features.

--- a/src/core.ts
+++ b/src/core.ts
@@ -1430,6 +1430,7 @@ function _buildSquel(flavour: Flavour | null = null): Squel {
     table: unknown
     alias: string | null
     condition: unknown
+    isApply?: boolean
   }
 
   cls.JoinBlock = class extends cls.Block {
@@ -1503,7 +1504,7 @@ function _buildSquel(flavour: Flavour | null = null): Squel {
     _toParamString(options: ToParamOptions = {}): ParamString {
       let totalStr = ""
       const totalValues: any[] = []
-      for (const { type, table, alias, condition } of this._joins) {
+      for (const { type, table, alias, condition, isApply } of this._joins) {
         totalStr = _pad(totalStr, this.options.separator)
         let tableStr: string
         if (cls.isSquelBuilder(table)) {
@@ -1516,7 +1517,11 @@ function _buildSquel(flavour: Flavour | null = null): Squel {
         } else {
           tableStr = this._formatTableName(table)
         }
-        totalStr += `${type} JOIN ${tableStr}`
+        if (isApply) {
+          totalStr += `${type} ${tableStr}`
+        } else {
+          totalStr += `${type} JOIN ${tableStr}`
+        }
         if (alias) totalStr += ` ${this._formatTableAlias(alias)}`
         if (condition) {
           totalStr += " ON "

--- a/src/mssql.ts
+++ b/src/mssql.ts
@@ -214,6 +214,34 @@ squel.flavours.mssql = (_squel: Squel) => {
     }
   }
 
+  cls.MssqlJoinBlock = class extends cls.JoinBlock {
+    apply(table: unknown, alias: string | null = null, type = "CROSS"): void {
+      table = this._sanitizeTable(table, true)
+      alias = alias ? this._sanitizeTableAlias(alias) : alias
+
+      let applyType = type.toUpperCase()
+      if (!applyType.endsWith("APPLY")) {
+        applyType = `${applyType} APPLY`
+      }
+
+      this._joins.push({
+        type: applyType,
+        table,
+        alias,
+        condition: null,
+        isApply: true,
+      })
+    }
+
+    cross_apply(table: unknown, alias: string | null = null): void {
+      this.apply(table, alias, "CROSS")
+    }
+
+    outer_apply(table: unknown, alias: string | null = null): void {
+      this.apply(table, alias, "OUTER")
+    }
+  }
+
   cls.Select = class extends cls.QueryBuilder {
     constructor(options?: any, blocks: any = null) {
       const limitOffsetTopBlock = new cls.MssqlLimitOffsetTopBlock(options)
@@ -224,7 +252,7 @@ squel.flavours.mssql = (_squel: Squel) => {
         limitOffsetTopBlock.TOP(),
         new cls.GetFieldBlock(options),
         new cls.FromTableBlock(options),
-        new cls.JoinBlock(options),
+        new cls.MssqlJoinBlock(options),
         new cls.WhereBlock(options),
         new cls.GroupByBlock(options),
         new cls.HavingBlock(options),

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,6 +167,9 @@ export interface Select extends QueryBuilder {
     alias?: string | null,
     condition?: Conditional | null,
   ): this
+  apply?(table: Joinable, alias?: string | null, type?: string): this
+  cross_apply?(table: Joinable, alias?: string | null): this
+  outer_apply?(table: Joinable, alias?: string | null): this
   union(table: Joinable, type?: string): this
   union_all(table: Joinable): this
   for(str: string): this

--- a/tests/mssql.test.ts
+++ b/tests/mssql.test.ts
@@ -127,6 +127,52 @@ describe("MSSQL flavour", () => {
         )
       })
     })
+
+    describe("APPLY (cross/outer apply)", () => {
+      it("cross_apply with table name", () => {
+        sel.from("table1").cross_apply("table2", "t2")
+        expect(sel.toString()).toBe(
+          "SELECT * FROM table1 CROSS APPLY table2 t2",
+        )
+      })
+
+      it("outer_apply with table name", () => {
+        sel.from("table1").outer_apply("table2", "t2")
+        expect(sel.toString()).toBe(
+          "SELECT * FROM table1 OUTER APPLY table2 t2",
+        )
+      })
+
+      it("generic apply with uppercase type", () => {
+        sel.from("table1").apply("table2", "t2", "CROSS")
+        expect(sel.toString()).toBe(
+          "SELECT * FROM table1 CROSS APPLY table2 t2",
+        )
+      })
+
+      it("generic apply with lowercase/partial suffix type", () => {
+        sel.from("table1").apply("table2", "t2", "outer apply")
+        expect(sel.toString()).toBe(
+          "SELECT * FROM table1 OUTER APPLY table2 t2",
+        )
+      })
+
+      it("cross_apply with subquery and parameters", () => {
+        const sub = squel
+          .select()
+          .from("bar")
+          .where("bar.id = table1.id")
+          .where("bar.status = ?", "active")
+        sel.from("table1").cross_apply(sub, "s")
+        expect(sel.toString()).toBe(
+          "SELECT * FROM table1 CROSS APPLY (SELECT * FROM bar WHERE (bar.id = table1.id) AND (bar.status = 'active')) s",
+        )
+        expect(sel.toParam()).toEqual({
+          text: "SELECT * FROM table1 CROSS APPLY (SELECT * FROM bar WHERE (bar.id = table1.id) AND (bar.status = ?)) s",
+          values: ["active"],
+        })
+      })
+    })
   })
 
   describe("INSERT builder", () => {

--- a/tests/select.test.ts
+++ b/tests/select.test.ts
@@ -639,6 +639,14 @@ describe("SELECT builder", () => {
     })
   })
 
+  describe("APPLY (not available on generic select)", () => {
+    it("does not expose apply methods on generic select", () => {
+      expect(inst.apply).toBeUndefined()
+      expect(inst.cross_apply).toBeUndefined()
+      expect(inst.outer_apply).toBeUndefined()
+    })
+  })
+
   describe("cloning", () => {
     it("basic", () => {
       const newinst = inst.from("students").limit(10).clone()


### PR DESCRIPTION
# feat(mssql): add support for CROSS and OUTER APPLY

## Description
This PR implements support for `CROSS APPLY` and `OUTER APPLY` queries specifically for the Microsoft SQL Server (`mssql`) flavour. The methods are designed as dialect-specific additions and are not exposed on the generic `Select` query builder.

## Key Changes
* **Core & Dialect Builders:**
  * Updated [core.ts](file:///Users/vimleshkumar/Desktop/open-source/real-squel-setup/squel/src/core.ts) to support bypassing the `JOIN` keyword if the join metadata flag `isApply` is enabled.
  * Introduced [MssqlJoinBlock](file:///Users/vimleshkumar/Desktop/open-source/real-squel-setup/squel/src/mssql.ts) extending standard `JoinBlock` with `apply()`, `cross_apply()`, and `outer_apply()` methods.
* **Typings:**
  * Added optional type definitions for `.apply()`, `.cross_apply()`, and `.outer_apply()` in the `Select` interface inside [types.ts](file:///Users/vimleshkumar/Desktop/open-source/real-squel-setup/squel/src/types.ts).
* **Documentation:**
  * Added clear usage examples in the "Modern SQL Features" section of [README.md](file:///Users/vimleshkumar/Desktop/open-source/real-squel-setup/squel/README.md).
* **Testing:**
  * Added comprehensive tests in [mssql.test.ts](file:///Users/vimleshkumar/Desktop/open-source/real-squel-setup/squel/tests/mssql.test.ts) covering name-based table references, subqueries with parameterized values, and casing variations.
  * Added isolation tests in [select.test.ts](file:///Users/vimleshkumar/Desktop/open-source/real-squel-setup/squel/tests/select.test.ts) to verify that `apply` helper methods are not exposed on generic SQL query builder instances.

## Verification
All checks pass successfully on local environment:
- `bun run check` (Linting & Formatting check: biome) - **Passed**
- `bun run typecheck` (TypeScript validation) - **Passed**
- `bun test` (Test suite run) - **Passed (664 tests passing)**
- `bun run build` (Dual-module bundling & types generation) - **Passed**
