### PR TITLE
Update types to reflect that `BaseBuilder` is accepted by `with`/`and`/`or`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -104,8 +104,11 @@ export interface QueryBuilder extends BaseBuilder {
   blocks: unknown[]
   updateOptions(options: QueryBuilderOptions): void
   getBlock<T>(blockType: new (...args: any[]) => T): T | undefined
-  with(alias: string, table: QueryBuilder): this
-  withRecursive(alias: string, table: QueryBuilder): this
+  // `table` only needs to be renderable; the WithBlock just forwards to
+  // `table._toParamString(...)` at build time, so any BaseBuilder is fine
+  // (including the raw-string builders returned by `rstr(...)`).
+  with(alias: string, table: BaseBuilder): this
+  withRecursive(alias: string, table: BaseBuilder): this
   [method: string]: unknown
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,8 +79,8 @@ export interface BaseBuilder extends Cloneable {
 }
 
 export interface Expression extends BaseBuilder {
-  and(expr: string | Expression | QueryBuilder, ...params: unknown[]): this
-  or(expr: string | Expression | QueryBuilder, ...params: unknown[]): this
+  and(expr: Conditional, ...params: unknown[]): this
+  or(expr: Conditional, ...params: unknown[]): this
 }
 
 export interface Case extends BaseBuilder {

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,9 +104,6 @@ export interface QueryBuilder extends BaseBuilder {
   blocks: unknown[]
   updateOptions(options: QueryBuilderOptions): void
   getBlock<T>(blockType: new (...args: any[]) => T): T | undefined
-  // `table` only needs to be renderable; the WithBlock just forwards to
-  // `table._toParamString(...)` at build time, so any BaseBuilder is fine
-  // (including the raw-string builders returned by `rstr(...)`).
   with(alias: string, table: BaseBuilder): this
   withRecursive(alias: string, table: BaseBuilder): this
   [method: string]: unknown


### PR DESCRIPTION
After updating to version 6 we found some places in our existing code where we're using `squel.rstr(...)` within an expression, which works fine, but the type definition isn't happy with it:

<img width="938" height="162" alt="Screenshot 2026-06-15 at 16 22 27" src="https://github.com/user-attachments/assets/d778fd5c-0f66-4122-9f9b-89c2b7aa1371" />

Same goes for `.with(...)` where it's sometimes useful to fiddle with `squel.rstr` to add extra keywords:

<img width="1129" height="171" alt="Screenshot 2026-06-15 at 16 43 38" src="https://github.com/user-attachments/assets/643b61cf-9b47-40ed-882c-a272de3cc769" />

Seems like the right fix is to allow a `BaseBuilder` in those places.