### PR TITLE
feat(postgres): add pg_hint_plan hint support to the postgres flavour

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,20 @@ squel.useFlavour("mssql")
 // SELECT * FROM table1 CROSS APPLY table2 t2 OUTER APPLY (SELECT * FROM bar WHERE (bar.id = table1.id)) s
 ```
 
+#### Query planner hints (Postgres `pg_hint_plan`)
+
+The Postgres flavour can prepend a [`pg_hint_plan`](https://pg-hint-plan.readthedocs.io/) hint comment to a `SELECT`, `INSERT`, `UPDATE` or `DELETE`. Repeated `hint(...)` calls accumulate into a single comment. The comment is inert unless the `pg_hint_plan` extension is loaded on the server.
+
+```javascript
+squel.useFlavour("postgres")
+    .select()
+    .hint("IndexScan(users users_email_idx)")
+    .hint("SeqScan(orders)")
+    .from("users")
+    .toString()
+// /*+ IndexScan(users users_email_idx) SeqScan(orders) */ SELECT * FROM users
+```
+
 ## Non-standard SQL flavours
 
 Squel supports the standard SQL commands and reserved words. A number of database engines provide their own non-standard commands; Squel makes it easy to load different "flavours" of SQL that augment the core builders with engine-specific features.

--- a/src/postgres.ts
+++ b/src/postgres.ts
@@ -149,9 +149,32 @@ squel.flavours.postgres = (_squel: Squel) => {
     }
   }
 
+  // Renders a pg_hint_plan hint comment (e.g. `/*+ IndexScan(t) */`) at the very
+  // start of the statement. Multiple hints accumulate space-separated inside a
+  // single comment. Requires the pg_hint_plan extension to have any effect; it is
+  // an inert SQL comment otherwise. See https://pg-hint-plan.readthedocs.io/
+  cls.PgHintPlanBlock = class extends cls.Block {
+    _hints: string[]
+
+    constructor(options: any) {
+      super(options)
+      this._hints = []
+    }
+
+    hint(hintStr: string): void {
+      this._hints.push(hintStr)
+    }
+
+    _toParamString(): any {
+      const text = this._hints.length ? `/*+ ${this._hints.join(" ")} */` : ""
+      return { text, values: [] }
+    }
+  }
+
   cls.Select = class extends cls.QueryBuilder {
     constructor(options?: any, blocks: any = null) {
       blocks = blocks || [
+        new cls.PgHintPlanBlock(options),
         new cls.WithBlock(options),
         new cls.StringBlock(options, "SELECT"),
         new cls.FunctionBlock(options),
@@ -175,6 +198,7 @@ squel.flavours.postgres = (_squel: Squel) => {
   cls.Insert = class extends cls.QueryBuilder {
     constructor(options?: any, blocks: any = null) {
       blocks = blocks || [
+        new cls.PgHintPlanBlock(options),
         new cls.WithBlock(options),
         new cls.StringBlock(options, "INSERT"),
         new cls.IntoTableBlock(options),
@@ -190,6 +214,7 @@ squel.flavours.postgres = (_squel: Squel) => {
   cls.Update = class extends cls.QueryBuilder {
     constructor(options?: any, blocks: any = null) {
       blocks = blocks || [
+        new cls.PgHintPlanBlock(options),
         new cls.WithBlock(options),
         new cls.StringBlock(options, "UPDATE"),
         new cls.UpdateTableBlock(options),
@@ -207,6 +232,7 @@ squel.flavours.postgres = (_squel: Squel) => {
   cls.Delete = class extends cls.QueryBuilder {
     constructor(options?: any, blocks: any = null) {
       blocks = blocks || [
+        new cls.PgHintPlanBlock(options),
         new cls.WithBlock(options),
         new cls.StringBlock(options, "DELETE"),
         new cls.TargetTableBlock(options),

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,12 @@ export interface QueryBuilder extends BaseBuilder {
   getBlock<T>(blockType: new (...args: any[]) => T): T | undefined
   with(alias: string, table: QueryBuilder): this
   withRecursive(alias: string, table: QueryBuilder): this
+  /**
+   * Postgres flavour only: prepend a pg_hint_plan hint comment to the
+   * statement, e.g. `hint("IndexScan(t)")`. Repeated calls accumulate into a
+   * single comment. See https://pg-hint-plan.readthedocs.io/
+   */
+  hint(hintStr: string): this
   [method: string]: unknown
 }
 

--- a/tests/postgres.test.ts
+++ b/tests/postgres.test.ts
@@ -669,6 +669,89 @@ describe("Postgres flavour", () => {
     })
   })
 
+  describe("pg_hint_plan hints", () => {
+    describe(">> select().hint(...)", () => {
+      it("prepends a hint comment", () => {
+        expect(
+          squel
+            .select()
+            .hint("IndexScan(t idx)")
+            .field("id")
+            .from("t")
+            .toString(),
+        ).toBe("/*+ IndexScan(t idx) */ SELECT id FROM t")
+      })
+
+      it("accumulates multiple hints into a single comment", () => {
+        expect(
+          squel
+            .select()
+            .hint("IndexScan(t idx)")
+            .hint("SeqScan(u)")
+            .from("t")
+            .toString(),
+        ).toBe("/*+ IndexScan(t idx) SeqScan(u) */ SELECT * FROM t")
+      })
+
+      it("renders nothing when unused", () => {
+        expect(squel.select().from("t").toString()).toBe("SELECT * FROM t")
+      })
+
+      it("does not affect parameter numbering", () => {
+        expect(
+          squel
+            .select()
+            .hint("IndexScan(t)")
+            .from("t")
+            .where("a = ?", 1)
+            .toParam(),
+        ).toEqual({
+          text: "/*+ IndexScan(t) */ SELECT * FROM t WHERE (a = $1)",
+          values: [1],
+        })
+      })
+
+      it("comes before a CTE", () => {
+        const cte = squel.select().from("u")
+        expect(
+          squel
+            .select()
+            .hint("IndexScan(t)")
+            .with("c", cte)
+            .from("t")
+            .toString(),
+        ).toBe(
+          "/*+ IndexScan(t) */ WITH c AS (SELECT * FROM u) SELECT * FROM t",
+        )
+      })
+
+      it("survives clone()", () => {
+        const sel = squel.select().hint("IndexScan(t)").from("t")
+        expect(sel.clone().toString()).toBe(
+          "/*+ IndexScan(t) */ SELECT * FROM t",
+        )
+      })
+    })
+
+    it(">> insert().hint(...)", () => {
+      expect(
+        squel.insert().hint("IndexScan(t)").into("t").set("a", 1).toString(),
+      ).toBe("/*+ IndexScan(t) */ INSERT INTO t (a) VALUES (1)")
+    })
+
+    it(">> update().hint(...)", () => {
+      expect(
+        squel.update().hint("IndexScan(t)").table("t").set("a", 1).toString(),
+      ).toBe("/*+ IndexScan(t) */ UPDATE t SET a = 1")
+    })
+
+    it(">> delete().hint(...)", () => {
+      expect(squel.delete().hint("IndexScan(t)").from("t").toString()).toBe(
+        "/*+ IndexScan(t) */ DELETE FROM t",
+      )
+    })
+  })
+
   it("Default query builder options", () => {
     expect(squel.cls.DefaultQueryBuilderOptions).toEqual({
       replaceSingleQuotes: false,


### PR DESCRIPTION
Add a `.hint(...)` method to the Postgres flavour's `SELECT`/`INSERT`/`UPDATE`/`DELETE` builders. It prepends a `pg_hint_plan` comment (e.g. an `/*+ IndexScan(...) */` directive) at the very start of the statement, ahead of any CTE. Repeated calls accumulate space-separated hints inside one comment, and the block renders nothing when unused so it never affects parameter numbering. The comment is inert unless the `pg_hint_plan` extension is loaded server-side.

This might be too niche for a generic library, but I've found it pretty cumbersome to add it outside the library, as it requires subclassing each core query builder:

```js
class PgHintPlanBlock extends cls.Block { /* ... */ }

class SquelSelectWithHints extends squel.cls.Select {
  constructor(options?: QueryBuilderOptions, blocks?: BaseBuilder[]) {
    super(
      options,
      blocks ?? [
        new PgHintPlanBlock(options),
        ...new squel.cls.Select(options).blocks,
      ],
    );
  }
}

class SquelUpdateWithHints extends squel.cls.Update { /* ... */ }
```

Happy to hear it if there's a simpler way of accomplishing it outside the library, or if it'd be more acceptable to have a more generic "leading comment" block.