### PR TITLE
fix(ci): float release Node version to satisfy npm's engine requirement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node (for npm publish with OIDC)
         uses: actions/setup-node@v4
         with:
-          node-version: "22.14.0"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm to latest (required for OIDC trusted publishing)


### PR DESCRIPTION
## Summary
- The release workflow (failed run: https://github.com/hiddentao/squel/actions/runs/31253577777/job/93093528658#step:6:1) pins Node to 22.14.0, but npm install -g npm@latest now installs npm 12.0.2, which requires Node ^22.22.2 || ^24.15.0 || >=26.0.0. That mismatch fails with EBADENGINE before publishing can happen.
- Change node-version to "22" so actions/setup-node always resolves the latest 22.x patch release, which satisfies npm 12s engine requirement now and going forward.

## Test plan
- [ ] Merge and confirm the next Release workflow run gets past the npm install -g npm@latest step
